### PR TITLE
Allow users to configure the db schema

### DIFF
--- a/src/meuse/db.clj
+++ b/src/meuse/db.clj
@@ -12,7 +12,7 @@
 (def default-ssl-mode "verify-full")
 
 (defn pool
-  [{:keys [user password host port name max-pool-size key cert cacert ssl-password ssl-mode]}]
+  [{:keys [user password host port name max-pool-size key cert cacert ssl-password ssl-mode schema]}]
   (log/debug {} "starting database connection pool")
   (let [url (format "jdbc:postgresql://%s:%d/%s"
                     host port name)
@@ -22,6 +22,8 @@
                  (.addDataSourceProperty "user" user)
                  (.addDataSourceProperty "password" password)
                  (.setMaximumPoolSize (or max-pool-size default-pool-size)))]
+    (when schema
+        (.addDataSourceProperty config "currentSchema" schema))
     (when key
       (log/info {} "ssl enabled for the database")
       (.addDataSourceProperty config "ssl" true)

--- a/src/meuse/spec.clj
+++ b/src/meuse/spec.clj
@@ -67,6 +67,7 @@
 (s/def :db/cert ::file)
 (s/def :db/cacert ::file)
 (s/def :db/ssl-mode ::non-empty-string)
+(s/def :db/schema ::non-empty-string)
 
 (s/def :db/database (s/keys :req-un [:db/user
                                      :db/password
@@ -77,7 +78,8 @@
                                      :db/key
                                      :db/cert
                                      :db/cacert
-                                     :db/ssl-mode]))
+                                     :db/ssl-mode
+                                     :db/schema]))
 
 (s/def :http/port ::pos-int)
 (s/def :http/address ::non-empty-string)


### PR DESCRIPTION
This commit adds a new option called `schema` to the database
configuration.
This option can be used to configure the PostgreSQL schema.

When set, the option `currentSchema` will be set for the database jdbc
datasource.

From the PostgreSQL documentation jdbc documentation:

```
currentSchema = String

Specify the schema (or several schema separated by commas) to be set
in the search-path. This schema will be used to resolve unqualified
object names used in statements over this connection.
```

Fix #22 