### PR TITLE
Better error handling when a crate fails to be created

### DIFF
--- a/src/meuse/api/crate/new.clj
+++ b/src/meuse/api/crate/new.clj
@@ -4,6 +4,7 @@
             [meuse.auth.request :as auth-request]
             [meuse.crate :as crate]
             [meuse.db.public.crate :as public-crate]
+            [meuse.db.public.crate-version :as public-crate-version]
             [meuse.git :as git]
             [meuse.log :as log]
             [meuse.metadata :as metadata]
@@ -13,7 +14,7 @@
             [clojure.java.io :as io]))
 
 (defn new
-  [crate-db git-object crate-file-store request]
+  [crate-db crate-version-db git-object crate-file-store request]
   (params/validate-params request ::new)
   (let [{:keys [git-metadata raw-metadata crate-file] :as crate}
         (crate/request->crate request)]
@@ -32,16 +33,34 @@
                            raw-metadata
                            (auth-request/user-id request))
       ;; write the metadata file
-      (metadata/write-metadata (get-in request [:config :metadata :path])
-                               git-metadata)
-      ;; write the crate binary file
-      (store/write-file crate-file-store raw-metadata crate-file)
-      ;; git add
-      (git/add git-object)
-      ;; git commit
-      (apply git/commit git-object (msg/publish-commit-msg raw-metadata))
-      ;; git push
-      (git/push git-object))
+
+      (try
+        (metadata/write-metadata (get-in request [:config :metadata :path])
+                                 git-metadata)
+        ;; write the crate binary file
+
+        (store/write-file crate-file-store raw-metadata crate-file)
+        ;; git add
+
+        (git/add git-object)
+        ;; git commit
+
+        (apply git/commit git-object (msg/publish-commit-msg raw-metadata))
+        ;; git push
+
+        (git/push git-object)
+        (catch Exception e
+          (log/error (log/req-ctx request) e "fail to publish crate, rollback")
+          (git/reset-hard git-object)
+          (git/clean git-object)
+          (git/pull git-object)
+          (public-crate-version/delete crate-version-db
+                                       (:name raw-metadata)
+                                       (:vers raw-metadata))
+          (store/delete-file crate-file-store
+                             (:name raw-metadata)
+                             (:vers raw-metadata))
+          (throw e))))
     {:status 200
      :body {:warning {:invalid_categories []
                       :invalid_badges []

--- a/src/meuse/db/public/crate_version.clj
+++ b/src/meuse/db/public/crate_version.clj
@@ -9,7 +9,8 @@
   (last-updated [this n])
   (top-n-downloads [this n])
   (update-yank [this crate-name crate-version yanked?])
-  (sum-download-count [this]))
+  (sum-download-count [this])
+  (delete [this crate-name version]))
 
 (defrecord CrateVersionDB [database]
   ICrateVersionDB
@@ -24,7 +25,9 @@
   (update-yank [this crate-name crate-version yanked?]
     (crate-version/update-yank database crate-name crate-version yanked?))
   (sum-download-count [this]
-    (crate-version/sum-download-count database)))
+    (crate-version/sum-download-count database))
+  (delete [this crate-name version]
+    (crate-version/delete database crate-name version)))
 
 (defstate crate-version-db
   :start (CrateVersionDB. database))

--- a/src/meuse/db/queries/crate.clj
+++ b/src/meuse/db/queries/crate.clj
@@ -24,9 +24,9 @@
                 :v.document_vectors
                 :v.crate_id)
       (h/from [:crates :c])
-      (h/left-join [:crates_versions :v] [:and
-                                          [:= :c.id :v.crate_id]
-                                          [:= :v.version crate-version]])
+      (h/join [:crates_versions :v] [:and
+                                     [:= :c.id :v.crate_id]
+                                     [:= :v.version crate-version]])
       (h/where [:= :c.name crate-name])
       sql/format))
 

--- a/src/meuse/db/queries/crate_version.clj
+++ b/src/meuse/db/queries/crate_version.clj
@@ -126,3 +126,9 @@
 (defn top-n-downloads
   [n]
   (first-n-order-by n [:v.download_count :desc]))
+
+(defn delete
+  [id]
+  (-> (h/delete-from :crates_versions)
+      (h/where [:= :id id])
+      (sql/format)))

--- a/src/meuse/inject.clj
+++ b/src/meuse/inject.clj
@@ -106,7 +106,7 @@
     ;; crate
     (defmethod crates-api! :new
       [request]
-      (new/new crate-db git crate-file-store request))
+      (new/new crate-db crate-version-db git crate-file-store request))
 
     (defmethod crates-api! :yank
       [request]

--- a/src/meuse/store/filesystem.clj
+++ b/src/meuse/store/filesystem.clj
@@ -58,4 +58,9 @@
   (versions [this crate-name]
     (filesystem-versions base-path crate-name))
   (write-file [this raw-metadata crate-file]
-    (write base-path raw-metadata crate-file)))
+    (write base-path raw-metadata crate-file))
+  (delete-file [this crate-name version]
+    (io/delete-file (crate-file-path base-path
+                                     crate-name
+                                     version)
+                    true)))

--- a/src/meuse/store/protocol.clj
+++ b/src/meuse/store/protocol.clj
@@ -4,4 +4,5 @@
   (exists [this crate-name version])
   (get-file [this crate-name version])
   (versions [this crate-name])
-  (write-file [this raw-metadata crate-file]))
+  (write-file [this raw-metadata crate-file])
+  (delete-file [this crate-name version]))

--- a/src/meuse/store/s3.clj
+++ b/src/meuse/store/s3.clj
@@ -75,4 +75,8 @@
                       (:name raw-metadata)
                       (:vers raw-metadata)
                       crate-file
-                      prefix)))
+                      prefix))
+  (delete-file [this crate-name version]
+    (s3/delete-object credentials
+                      :bucket-name bucket
+                      :key (file-key crate-name version prefix))))

--- a/test/meuse/db/actions/crate_test.clj
+++ b/test/meuse/db/actions/crate_test.clj
@@ -12,6 +12,10 @@
 (use-fixtures :once system-fixture)
 (use-fixtures :each db-clean-fixture table-fixture)
 
+(deftest by-name-and-version-test
+  (is (map? (by-name-and-version database "crate1" "1.1.0")))
+  (is (nil? (by-name-and-version database "crate1" "1.2.0"))))
+
 (deftest create-test
   (let [crate {:name "test1"
                :vers "0.1.3"

--- a/test/meuse/db/actions/crate_version_test.clj
+++ b/test/meuse/db/actions/crate_version_test.clj
@@ -33,6 +33,12 @@
                           #"the version does not exist$"
                           (update-yank database "crate1" "0.1.4" false)))))
 
+(deftest delete-test
+  (testing "success"
+    (is (crate-db/by-name-and-version database "crate1" "1.1.0"))
+    (delete database "crate1" "1.1.0")
+    (is (nil? (crate-db/by-name-and-version database "crate1" "1.1.0")))))
+
 (deftest last-updated-test
   (let [crates (last-updated database 1)]
     (is (= 1 (count crates)))

--- a/test/meuse/git_test.clj
+++ b/test/meuse/git_test.clj
@@ -29,4 +29,4 @@
     (with-redefs [clojure.java.shell/sh (spy/spy (spy/stub {:exit 0}))]
       (pull git)
       (assert/called-once-with? clojure.java.shell/sh
-                                "git" "-C" tmp-dir "pull" "origin/master"))))
+                                "git" "-C" tmp-dir "pull" "origin" "master"))))

--- a/test/meuse/helpers/git.clj
+++ b/test/meuse/helpers/git.clj
@@ -13,4 +13,8 @@
   (push [this]
     (swap! state conj {:cmd "push"}))
   (pull [this]
-    (swap! state conj {:cmd "pull"})))
+    (swap! state conj {:cmd "pull"}))
+  (reset-hard [this]
+    (swap! state conj {:cmd "reset"}))
+  (clean [this]
+    (swap! state conj {:cmd "clean"})))

--- a/test/meuse/mocks/db.clj
+++ b/test/meuse/mocks/db.clj
@@ -43,7 +43,7 @@
 
 (defn crate-version-mock
   [{:keys [count-crates-versions inc-download last-updated
-           top-n-downloads update-yank sum-download-count]}]
+           top-n-downloads update-yank sum-download-count delete]}]
   (protocol/spy ICrateVersionDB
                 (reify ICrateVersionDB
                   (count-crates-versions [this] count-crates-versions)
@@ -51,7 +51,8 @@
                   (last-updated [this n] last-updated)
                   (top-n-downloads [this n] top-n-downloads)
                   (update-yank [this crate-name crate-version yanked?] update-yank)
-                  (sum-download-count [this] sum-download-count))))
+                  (sum-download-count [this] sum-download-count)
+                  (delete [this crate-name version] delete))))
 
 (defn search-mock
   [{:keys [search]}]


### PR DESCRIPTION
- rollback the git/metadata operations
- delete the crate from the db
- delete the crate from the store