### PR TITLE
[NEW] Add basic CI pipeline

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,43 @@
+name: CI
+
+on:
+  push:
+    branches: [ "master" ]
+  pull_request:
+    branches: [ "master" ]
+
+jobs:
+  build:
+
+    runs-on: ubuntu-latest
+
+    services:
+      postgres:
+        image: postgres
+
+        env:
+          POSTGRES_PASSWORD: meuse
+          POSTGRES_USER: meuse
+          POSTGRES_DB: meuse
+
+        options: >-
+          --health-cmd pg_isready
+          --health-interval 10s
+          --health-timeout 5s
+          --health-retries 5
+        ports:
+          - 5432:5432
+
+    steps:
+    - uses: actions/checkout@v3
+
+    - name: Create folders specified in default config
+      run: |
+        mkdir registry
+        mkdir crates
+
+    - name: Install dependencies
+      run: lein deps
+
+    - name: Run tests
+      run: lein test

--- a/dev/resources/config.yaml
+++ b/dev/resources/config.yaml
@@ -23,12 +23,12 @@ logging:
     com.amazonaws.requestId: warn
 metadata:
   type: "shell"
-  path: "/home/mcorbin/prog/rust/testregistry"
+  path: "registry"
   target: "origin/master"
   url: "https://github.com/mcorbin/testregistry"
 crate:
   store: "filesystem"
-  path: "/home/mcorbin/prog/rust/crates"
+  path: "crates"
 frontend:
   enabled: true
   secret: !secret uJo8QrRAANokteN_xVxpP75lc_A5Sw6t


### PR DESCRIPTION
This pull request adds a basic GitHub Actions CI pipeline to ensure master and pull requests pass the tests.
